### PR TITLE
ignore 998 if not exists

### DIFF
--- a/dlx_dl/scripts/sync/__init__.py
+++ b/dlx_dl/scripts/sync/__init__.py
@@ -562,7 +562,10 @@ def compare_and_update(args, *, dlx_record, dl_record):
             record.fields += dlx_record.get_fields(tag)
 
         record.fields += delete_fields
-        record.fields.append(dlx_record.get_field('998'))
+        _998 = dlx_record.get_field('998')
+
+        if _998:
+            record.fields.append(_998)
 
         return submit_to_dl(args, record, mode='correct', export_start=args.START, export_type='UPDATE')
 


### PR DESCRIPTION
closes #49 

Records that don't have 998 were throwing an error on sync attempt