### PR TITLE
install dlx-dl from current branch

### DIFF
--- a/aws-lambda/requirements.txt
+++ b/aws-lambda/requirements.txt
@@ -1,1 +1,1 @@
-dlx-dl @ git+https://github.com/dag-hammarskjold-library/dlx-dl
+../. # installs dlx-dl from the directory above


### PR DESCRIPTION
I think we still want to install dlx-dl from the current branch in the case where we want to invoke the Lambda function outside the CI/CD actions