### PR TITLE
Allow installation on Python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description = 'Export data fom DLX to DL',
     long_description = long_description,
     long_description_content_type = "text/markdown",
-    python_requires = '>=3.8, <=3.12',
+    python_requires = '>=3.8, <3.13',
     entry_points = {
         'console_scripts': [
             'dlx-dl=dlx_dl.scripts.export:run', # to deprecate


### PR DESCRIPTION
Support for 3.12 was enabled in #90, but setup.py was still preventing installation in Python 3.12 environments. This wasn't caught by the 3.12 tests because in the tests we don't actually install dlx-dl.