### PR TITLE
Adjust workflow to use a different ECR repository

### DIFF
--- a/.github/workflows/deploy-alert.yml
+++ b/.github/workflows/deploy-alert.yml
@@ -37,7 +37,7 @@ jobs:
           id: build-image
           env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-            ECR_REPOSITORY: ${{ secrets.REPO_NAME }}
+            ECR_REPOSITORY: dlx-dl-alert
             IMAGE_TAG: latest
           run: |
             cd ./dlx-dl-alert
@@ -50,7 +50,7 @@ jobs:
           id: deploy-image
           env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-            ECR_REPOSITORY: ${{ secrets.REPO_NAME }}
+            ECR_REPOSITORY: dlx-dl-alert
             IMAGE_TAG: latest
           run: |
             aws lambda update-function-code \


### PR DESCRIPTION
This should be deployable without colliding with the existing ECR repo