### PR TITLE
tweaks to allow for access key retirement in favor of aws login, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _build/
 /docs/_build/
 .DS_Store
 .vs
+*.egg-info
+build

--- a/dlx_dl/scripts/export.py
+++ b/dlx_dl/scripts/export.py
@@ -74,7 +74,8 @@ def get_args(**kwargs):
     om.add_argument('--use_api', '--api', action='store_true', help='submit records to DL through the API (boolean)')
     
     # get from AWS if not provided
-    ssm = boto3.client('ssm', region_name='us-east-1')
+    session = boto3.Session()
+    ssm = session.client("ssm")
     
     def param(name):
         return None if os.environ.get('DLX_DL_TESTING') else ssm.get_parameter(Name=name)['Parameter']['Value'] 
@@ -551,7 +552,7 @@ def _new_file_uris(date_from: datetime, date_to=None) -> list:
     
 def _fft_from_files(bib):
     symbols = bib.get_values('191', 'a') + bib.get_values('191', 'z')
-    
+
     seen = []
     
     for symbol in set(symbols):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.26
+dlx-odm==1.6.0
+boto3[crt]>=1.43.35
+botocore[crt]>=1.43.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dlx-odm==1.6.0
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.5.8
 boto3[crt]>=1.43.35
 botocore[crt]>=1.43.35

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description = 'Export data fom DLX to DL',
     long_description = long_description,
     long_description_content_type = "text/markdown",
-    python_requires = '>=3.10, <=3.14',
+    python_requires = '>=3.10, <3.15',
     entry_points = {
         'console_scripts': [
             'dlx-dl=dlx_dl.scripts.export:run', # to deprecate


### PR DESCRIPTION
The update here sets things up so we don't have to keep AWS keys on hand in our local environments. Instead we would use the `aws login` command to get a temporary session.

This needs to be tested within the deployment context.